### PR TITLE
Fixes #20 where completion suggestions are not showing description.

### DIFF
--- a/lib/autocomplete-elixir-provider.coffee
+++ b/lib/autocomplete-elixir-provider.coffee
@@ -76,8 +76,8 @@
           suggestion =
             snippet:  if one then prefix + postfix + word else word
             displayText:  if one then prefix + postfix + word else word
-            prefix:  if one then prefix + postfix else last
-            label: if ret then ret else "any"
+            replacementPrefix:  if one then prefix + postfix else last
+            rightLabel: if ret then ret else "any"
             type: type
             description: spec || ret || "Desc"
             #inclusionPriority: -1


### PR DESCRIPTION
The properties `prefix` and `label` are now depreciated in core atom, and have been changed to `replacementPrefix` and `rightLabel`